### PR TITLE
bug :  api 서버 빌드시 정적파일 경로 복사 추가

### DIFF
--- a/HIGOODS-Api/Dockerfile
+++ b/HIGOODS-Api/Dockerfile
@@ -3,6 +3,7 @@ FROM openjdk:17-alpine
 EXPOSE 8080
 
 COPY ./build/libs/*.jar app.jar
+COPY ./src/main/resources/static /app/src/main/resources/static
 ARG PROFILE=dev
 ENV PROFILE=${PROFILE}
 


### PR DESCRIPTION
## 개요
- close #58 

## 작업사항
- api 서버 빌드시 정적파일 경로 복사 추가
해당 수정 사항 반영 후 배포 서버에서 정적경로 접속시 잘 접속되는 거 확인 완료~
![image](https://github.com/higoods-hongik/HIGOODS-Backend/assets/67696767/77c3776c-7e84-467c-a6d3-e0f6b7396dd4)


## 변경로직
- 내용을 적어주세요.