### PR TITLE
feat : restdoc swagger jwt bearer 세팅

### DIFF
--- a/HIGOODS-Api/build.gradle.kts
+++ b/HIGOODS-Api/build.gradle.kts
@@ -1,3 +1,5 @@
+
+import org.hidetake.gradle.swagger.generator.GenerateSwaggerCode
 import org.hidetake.gradle.swagger.generator.GenerateSwaggerUI
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
@@ -35,10 +37,13 @@ dependencies {
 
     testImplementation(Dependencies.REST_DOC)
     testImplementation(Dependencies.REST_DOC_API_SPEC)
-    swaggerUI(Dependencies.SWAGGER_UI)
+    swaggerUI("org.webjars:swagger-ui:4.11.1")
 
     tasks {
         withType<Jar> { enabled = false }
+        withType<GenerateSwaggerCode> {
+            language = "asdf"
+        }
         withType<GenerateSwaggerUI> {
             dependsOn("openapi3")
         }

--- a/HIGOODS-Api/build.gradle.kts
+++ b/HIGOODS-Api/build.gradle.kts
@@ -1,5 +1,3 @@
-
-import org.hidetake.gradle.swagger.generator.GenerateSwaggerCode
 import org.hidetake.gradle.swagger.generator.GenerateSwaggerUI
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
@@ -37,13 +35,10 @@ dependencies {
 
     testImplementation(Dependencies.REST_DOC)
     testImplementation(Dependencies.REST_DOC_API_SPEC)
-    swaggerUI("org.webjars:swagger-ui:4.11.1")
+    swaggerUI(Dependencies.SWAGGER_UI)
 
     tasks {
         withType<Jar> { enabled = false }
-        withType<GenerateSwaggerCode> {
-            language = "asdf"
-        }
         withType<GenerateSwaggerUI> {
             dependsOn("openapi3")
         }

--- a/HIGOODS-Api/src/test/kotlin/com/higoods/api/auth/AuthControllerTest.kt
+++ b/HIGOODS-Api/src/test/kotlin/com/higoods/api/auth/AuthControllerTest.kt
@@ -17,7 +17,6 @@ import com.higoods.api.auth.usecase.WithDrawUseCase
 import com.higoods.api.common.BOOLEAN
 import com.higoods.api.common.BaseControllerTest
 import com.higoods.api.common.DocumentObjects
-import com.higoods.api.common.DocumentObjects.authorizationHeaderDocs
 import com.higoods.api.common.NUMBER
 import com.higoods.api.common.OpenApiTag
 import com.higoods.api.common.STRING
@@ -197,8 +196,7 @@ class AuthControllerTest : BaseControllerTest() {
             }
                 .isStatus(200)
                 .makeDocument(
-                    DocumentInfo(identifier = "로그아웃", tag = OpenApiTag.AUTH, description = "로그아웃"),
-                    authorizationHeaderDocs
+                    DocumentInfo(identifier = "로그아웃", tag = OpenApiTag.AUTH, description = "로그아웃")
                 )
         }
 
@@ -210,8 +208,7 @@ class AuthControllerTest : BaseControllerTest() {
             }
                 .isStatus(200)
                 .makeDocument(
-                    DocumentInfo(identifier = "회원탈퇴", tag = OpenApiTag.AUTH, description = "회원탈퇴"),
-                    authorizationHeaderDocs
+                    DocumentInfo(identifier = "회원탈퇴", tag = OpenApiTag.AUTH, description = "회원탈퇴")
                 )
         }
     }

--- a/HIGOODS-Api/src/test/kotlin/com/higoods/api/common/BaseControllerTest.kt
+++ b/HIGOODS-Api/src/test/kotlin/com/higoods/api/common/BaseControllerTest.kt
@@ -153,7 +153,11 @@ abstract class BaseControllerTest : FunSpec() {
             "user",
             authDetails.authorities
         )
-        this.header(HttpHeaders.AUTHORIZATION, "bearerAuthJWT")
+        // 실제 토큰을 집어넣는이유.
+        // https://github.com/ePages-de/restdocs-api-spec/pull/86
+        // https://github.com/ePages-de/restdocs-api-spec/blob/4c735ca2796d0620ecef30e20471a173cec0809b/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/JwtSecurityHandler.kt#L14
+        // 복호화해서 scope 들어있는 oauth 헤더가 아니면 자동으로 좌물쇠 채워주는 소스가 있습니다.
+        this.header(HttpHeaders.AUTHORIZATION, "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
     }
 
     protected fun ResultActions.isStatus(code: Int): ResultActions =
@@ -170,7 +174,6 @@ abstract class BaseControllerTest : FunSpec() {
                     .description(documentInfo.description)
                     .deprecated(documentInfo.deprecated)
                     .tag(documentInfo.tag.value),
-
                 snippets = snippets
             )
         )

--- a/HIGOODS-Api/src/test/kotlin/com/higoods/api/common/DocumentObjects.kt
+++ b/HIGOODS-Api/src/test/kotlin/com/higoods/api/common/DocumentObjects.kt
@@ -16,8 +16,6 @@ object DocumentObjects : BaseControllerTest() {
         "user.fcmInfo.appAlarm" type BOOLEAN means "FcmNotificationVo"
     ).toTypedArray()
 
-    val authorizationHeaderDocs = requestHeaders("Authorization" type STRING means "bearerAuthJWT")
-
     override val controller: Any
         get() = OBJECT
 }


### PR DESCRIPTION
## 개요
- close #77 

## 작업사항
- 내용을 적어주세요.


document 작성은 필요없고
모킹 요청에 헤더에 jwt 실어보내면

docs 오퍼레이션으로 만들어지고

그게 쭉 가다가
나중에 openapi3.yml 로 변경될때
해당 오퍼레이션에 jwt 토큰 bearer auth가 있는지 판단해서
좌물쇠 껴주는 느낌

## 변경로직
- 내용을 적어주세요.